### PR TITLE
denops v7

### DIFF
--- a/denops/@tataku/emitter/nvim_floatwin.ts
+++ b/denops/@tataku/emitter/nvim_floatwin.ts
@@ -8,7 +8,7 @@ import {
   $union,
   access,
   type Infer,
-} from "https://esm.sh/lizod@0.2.7/";
+} from "npm:lizod@0.2.7";
 
 function resolveBorder(
   border: Border,

--- a/denops/@tataku/emitter/nvim_floatwin.ts
+++ b/denops/@tataku/emitter/nvim_floatwin.ts
@@ -1,4 +1,4 @@
-import { Denops } from "https://deno.land/x/denops_std@v6.5.1/mod.ts";
+import { Denops } from "jsr:@denops/std@7.0.0";
 import {
   $array,
   $boolean,


### PR DESCRIPTION
- **chore: replace to `npm:` specifier**
- **chore: migrate denops v7**
