### PR TITLE
ci: add a permission to label pr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change adds write permissions for issues in the `release.yml` workflow file.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R24): Added `permission-issues: write` to the `jobs` section to enable the workflow to write to issues.